### PR TITLE
Remove manual fixes for HTML minification

### DIFF
--- a/.htmlnanorc
+++ b/.htmlnanorc
@@ -1,5 +1,4 @@
 {
-    minifySvg: false,
     // Keep Knockout.js comments in HTML, even when minifying
     // https://github.com/parcel-bundler/parcel/issues/1218
     // https://github.com/parcel-bundler/parcel/issues/429

--- a/.posthtmlrc
+++ b/.posthtmlrc
@@ -1,4 +1,0 @@
-{
-    "recognizeSelfClosing": true,
-    "lowerCaseAttributeNames": false
-}


### PR DESCRIPTION
Parcel used to break embedded SVG elements by lower-casing `viewBox` attributes. This has now been fixed as of Parcel v1.11.0, so we don't need to override these settings anymore.

Closes #2